### PR TITLE
Fix 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/passwordreset/ResetLinkAssignmentForgotPassword.java
+++ b/src/main/java/org/owasp/webgoat/lessons/passwordreset/ResetLinkAssignmentForgotPassword.java
@@ -23,6 +23,7 @@
 package org.owasp.webgoat.lessons.passwordreset;
 
 import java.util.UUID;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AttackResult;
@@ -68,6 +69,9 @@ public class ResetLinkAssignmentForgotPassword extends AssignmentEndpoint {
     String resetLink = UUID.randomUUID().toString();
     ResetLinkAssignment.resetLinks.add(resetLink);
     String host = request.getHeader("host");
+    if (!isAuthorizedHost(host)) {
+        return failed(this).output("Unauthorized host.").build();
+    }
     if (ResetLinkAssignment.TOM_EMAIL.equals(email)
         && (host.contains(webWolfPort)
             || host.contains(webWolfHost))) { // User indeed changed the host header.
@@ -110,5 +114,10 @@ public class ResetLinkAssignmentForgotPassword extends AssignmentEndpoint {
     } catch (Exception e) {
       // don't care
     }
+  }
+
+  private boolean isAuthorizedHost(String host) {
+    List<String> authorizedHosts = List.of(webWolfHost, "another-authorized-host.com");
+    return authorizedHosts.contains(host);
   }
 }

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -46,21 +46,24 @@ public class SSRFTask2 extends AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
-      String html;
-      try (InputStream in = new URL(url).openStream()) {
-        html =
-            new String(in.readAllBytes(), StandardCharsets.UTF_8)
-                .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
-      } catch (MalformedURLException e) {
-        return getFailedResult(e.getMessage());
-      } catch (IOException e) {
-        // in case the external site is down, the test and lesson should still be ok
-        html =
-            "<html><body>Although the http://ifconfig.pro site is down, you still managed to solve"
-                + " this exercise the right way!</body></html>";
+    try {
+      URL parsedUrl = new URL(url);
+      if ("ifconfig.pro".equals(parsedUrl.getHost()) && "http".equals(parsedUrl.getProtocol())) {
+        String html;
+        try (InputStream in = parsedUrl.openStream()) {
+          html =
+              new String(in.readAllBytes(), StandardCharsets.UTF_8)
+                  .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
+        } catch (IOException e) {
+          // in case the external site is down, the test and lesson should still be ok
+          html =
+              "<html><body>Although the http://ifconfig.pro site is down, you still managed to solve"
+                  + " this exercise the right way!</body></html>";
+        }
+        return success(this).feedback("ssrf.success").output(html).build();
       }
-      return success(this).feedback("ssrf.success").output(html).build();
+    } catch (MalformedURLException e) {
+      return getFailedResult(e.getMessage());
     }
     var html = "<img class=\"image\" alt=\"image post\" src=\"images/cat.jpg\">";
     return getFailedResult(html);

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Fixes 3 code scanning alerts:
- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/34
To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of authorized URLs or restricted to a particular host or URL prefix. In this case, we can validate the URL to ensure it matches the allowed host (`ifconfig.pro`) and uses the HTTP protocol.

  1. Parse the user-provided URL and extract the host.
  2. Check if the host matches the allowed host (`ifconfig.pro`).
  3. Ensure the URL uses the HTTP protocol.
  


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/33
To fix the SSRF vulnerability, we need to validate the `host` header before using it to construct the URL. One way to do this is to maintain a list of authorized hosts and ensure that the `host` header matches one of these authorized hosts. This approach prevents an attacker from injecting arbitrary hosts.

  1. Create a list of authorized hosts.
  2. Check if the `host` header is in the list of authorized hosts before using it.
  3. If the `host` is not authorized, handle the error appropriately.
  


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat/security/code-scanning/28
To fix the problem, we need to ensure that the XML parser is always securely configured to prevent XXE attacks, regardless of the `webSession.isSecurityEnabled()` flag. This involves disabling the parsing of external entities and DTDs unconditionally.

  - Modify the `parseXml` method in `CommentsCache` class to always disable external DTDs and schemas.
  - Ensure that the `XMLInputFactory` is securely configured before creating the `XMLStreamReader`.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._